### PR TITLE
fix: Fix navabar width for wider screen sizes

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -25,7 +25,7 @@ const Navbar = () => {
 
 	return (
 		<div
-			className={`fixed w-screen lg:w-[95.7%] top-0 right-0 lg:ml-20 z-40 ${
+			className={`fixed w-screen top-0 right-0 z-40 lg:pl-24 ${
 				scrolled
 					? "bg-blue-100 dark:bg-gray-900 dark:shadow-gray-800 shadow-gray-300 shadow "
 					: "bg-transparent"


### PR DESCRIPTION
Fixes #1 

Removed the white space between navbar and sidebar that was visible on wide screen sizes.

Screenshot:
![image](https://github.com/iamjunaidjutt/iamjunaidjutt-portfolio/assets/119912892/fa375721-5ff9-4562-9936-e00a021a67ae)
